### PR TITLE
Handle symbolic links to transrate wrapper

### DIFF
--- a/packaging/transrate
+++ b/packaging/transrate
@@ -2,7 +2,8 @@
 set -e
 
 # Figure out where this script is located.
-SELFDIR="`dirname \"$0\"`"
+SELFSCRIPT="`readlink -f \"$0\"`"
+SELFDIR="`dirname \"$SELFSCRIPT\"`"
 SELFDIR="`cd \"$SELFDIR\" && pwd`"
 
 # Temporarily set PATH and LD_LIBRARY_PATH


### PR DESCRIPTION
Hi @Blahah,

Happy holidays to you. This allows a symbolic link to be made to the `transrate` wrapper and have it get resolved to the correct directory which will let this get made into a bioconda package without mucking anything else up.