### PR TITLE
A few changes to Transrate

### DIFF
--- a/deps/deps.yaml
+++ b/deps/deps.yaml
@@ -38,9 +38,9 @@ salmon:
     - libtbbmalloc.dylib
     - libtbbmalloc_proxy.dylib
   version:
-    number: '0.6.0'
+    number: '0.8.2'
     command: 'salmon -v'
   url:
     64bit:
-      linux: https://github.com/COMBINE-lab/salmon/releases/download/v0.6.0/SalmonBeta-0.6.0_DebianSqueeze.tar.gz
-      macosx: https://github.com/COMBINE-lab/salmon/releases/download/v0.6.0/SalmonBeta-0.6.0_OSX_10.11.tar.gz
+      linux: https://github.com/COMBINE-lab/salmon/releases/download/v0.8.2/Salmon-0.8.2_linux_x86_64.tar.gz
+      macosx: https://github.com/COMBINE-lab/salmon/releases/download/v0.8.2/Salmon-0.8.2_macOS_10.12.tar.gz

--- a/lib/transrate/salmon.rb
+++ b/lib/transrate/salmon.rb
@@ -37,17 +37,16 @@ module Transrate
 
     def build_command assembly, bamfile, threads=4
       cmd = "#{@salmon} quant"
-      cmd << " --libType IU"
       cmd << " --alignments #{bamfile}"
       cmd << " --targets #{assembly}"
       cmd << " --threads #{threads}"
       cmd << " --sampleOut"
       cmd << " --sampleUnaligned" # thanks Rob!
       cmd << " --output ."
+      cmd << " --seqBias"
       cmd << " --useErrorModel"
-      cmd << " --biasCorrect"
-      cmd << " --noEffectiveLengthCorrection"
-      cmd << " --useFSPD"
+      cmd << " --gcBias"
+      cmd << " --libType a"
       cmd
     end
 

--- a/lib/transrate/snap.rb
+++ b/lib/transrate/snap.rb
@@ -37,8 +37,7 @@ module Transrate
       cmd << " -D 5" # extra edit distance to search. needed for -om
       cmd << " -om 5" # Output multiple alignments. extra edit distance
       cmd << " -omax 10" # max alignments per pair/read
-      cmd << " -mcp 10000000000000" # increase mcp tp silly high value to dec incidence of common SNAP fail. 
-
+      cmd << " -mcp 10000000000000" # increase mcp to silly high value to dec incidence of common SNAP fail. 
       cmd
     end
 

--- a/lib/transrate/snap.rb
+++ b/lib/transrate/snap.rb
@@ -37,6 +37,8 @@ module Transrate
       cmd << " -D 5" # extra edit distance to search. needed for -om
       cmd << " -om 5" # Output multiple alignments. extra edit distance
       cmd << " -omax 10" # max alignments per pair/read
+      cmd << " -mcp 10000000000000" # increase mcp tp silly high value to dec incidence of common SNAP fail. 
+
       cmd
     end
 


### PR DESCRIPTION
Changes:

- Add `-mcp` flag to SNAP, which will clean up *one* of the common errors that users encounter.
- Update to Salmon 0.8.2. 

Issues: 

- I don't know how you typically build the binary, so can't do that. With the current 1.0.3 binary, one of the files in lib/ needs to be deleted, as it causes issues with, I think, more modern versions of GCC.  