### PR TITLE
Update snap.rb to fix failure to build index

### DIFF
--- a/lib/transrate/snap.rb
+++ b/lib/transrate/snap.rb
@@ -138,7 +138,7 @@ module Transrate
           runner.run
           if !runner.status.success?
             err = runner.stderr
-            if err =~ /Ran out of overflow table namespace/ || err =~ /Trying to use too many overflow entries/
+            if err =~ /Ran out of overflow table namespace/ || err =~ /Trying to use too many overflow entries/ || err =~ /Genome is too big for 4 byte genome locations/
               logger.warn "Snap index build failed with n = #{n} , increasing +1"
               n += 1
               Dir.delete(@index_name) if Dir.exist?(@index_name)

--- a/lib/transrate/snap.rb
+++ b/lib/transrate/snap.rb
@@ -6,6 +6,7 @@ module Transrate
   class Snap
 
     require 'bio'
+    require 'fileutils'
 
     attr_reader :index_name, :bam, :read_count
 
@@ -141,7 +142,7 @@ module Transrate
             if err =~ /Ran out of overflow table namespace/ || err =~ /Trying to use too many overflow entries/ || err =~ /Genome is too big for 4 byte genome locations/
               logger.warn "Snap index build failed with n = #{n} , increasing +1"
               n += 1
-              Dir.delete(@index_name) if Dir.exist?(@index_name)
+              FileUtils.rm_rf(@index_name) if Dir.exist?(@index_name)
             else
               msg = "Failed to build Snap index\n#{runner.stderr}"
               raise SnapError.new(msg)


### PR DESCRIPTION
Try to rebuild the index with increased `-locationSize` to fix the following error:

> Genome is too big for 4 byte genome locations.  Specify a larger location size with -locationSize
> SNAP exited with exit code 1 from line 304 of file SNAPLib/GenomeIndex.cpp

A better solution may be to expose this parameter to `transrate` so the user can change it when invoking the pipeline.
